### PR TITLE
Put all db files in .unassigner/ by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Default database directory
+.unassigner/
+
 # LTP refs
 LTP_*.csv
 LTP_*.fasta

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-# Default database directory
-.unassigner/
-
-# LTP refs
-LTP_*.csv
-LTP_*.fasta
-
 # Vsearch databases
 *.udb
 

--- a/README.md
+++ b/README.md
@@ -115,16 +115,6 @@ Step 3: The last part of the software relies on building a database of the seque
 Please see the output of `trimragged --help` for a list of the available
 options.
 
-### Count mismatches
-
-
-
-### Percent ID ANI sample
-
-
-
-Should there also be a command and section for prepare_strain_data?
-
 ## Contributing
 
 We welcome ideas from our users about how to improve this

--- a/unassigner/command.py
+++ b/unassigner/command.py
@@ -91,20 +91,25 @@ def main(argv=None):
 
     query_seqs = list(parse_fasta(args.query_fasta, trim_desc=True))
 
-    if args.output_dir is None:
-        output_dir = os.path.splitext(args.query_fasta.name)[0] + "_unassigned"
-    else:
-        output_dir = args.output_dir
-
     # Download type strain files if needed
-    os.makedirs(args.db_dir, exist_ok=True)
-    ltp_fp = download_type_strain_data(output_dir=args.db_dir)
-
+    # 1. If arg is set, download the file and use it
+    # 2. If default file exists, use it
+    # 3. Otherwise put it in the output directory
     if args.type_strain_fasta is not None:
         logging.warning(
             "The --type_strain_fasta argument is deprecated. Please use --db_dir instead."
         )
         ltp_fp = args.type_strain_fasta
+    elif os.path.exists("unassigner_species.fasta"):
+        ltp_fp = "unassigner_species.fasta"
+    else:
+        if args.output_dir is None:
+            output_dir = os.path.splitext(args.query_fasta.name)[0] + "_unassigned"
+        else:
+            output_dir = args.output_dir
+
+        os.makedirs(args.db_dir, exist_ok=True)
+        ltp_fp = download_type_strain_data(output_dir=args.db_dir)
 
     with open(ltp_fp) as f:
         species_names = dict(parse_species_names(f))

--- a/unassigner/command.py
+++ b/unassigner/command.py
@@ -27,20 +27,19 @@ def main(argv=None):
         "--output_dir",
         help=(
             "Output directory (default: basename of query sequences FASTA "
-            "file, plus '_unassigned'. Note that it will be in the same "
-            "directory as the query sequences FASTA file)."
+            "file, plus '_unassigned')."
         ),
     )
     p.add_argument(
         "--type_strain_fasta",
         help=(
-            "FASTA file containing sequences of type strains. If not provided, "
+            "DEPRECATED. FASTA file containing sequences of type strains. If not provided, "
             "the default database is used. Note that this WILL NOT DOWNLOAD a new db."
         ),
     )
     p.add_argument(
         "--db_dir",
-        default=".unassigner/",
+        default="~/.unassigner/",
         help=(
             "Directory containing the reference database. If not provided, "
             "the default database is used."
@@ -99,9 +98,12 @@ def main(argv=None):
 
     # Download type strain files if needed
     os.makedirs(args.db_dir, exist_ok=True)
-    _, _, ltp_fp = download_type_strain_data(output_dir=args.db_dir)
+    ltp_fp = download_type_strain_data(output_dir=args.db_dir)
 
     if args.type_strain_fasta is not None:
+        logging.warning(
+            "The --type_strain_fasta argument is deprecated. Please use --db_dir instead."
+        )
         ltp_fp = args.type_strain_fasta
 
     with open(ltp_fp) as f:

--- a/unassigner/command.py
+++ b/unassigner/command.py
@@ -39,7 +39,7 @@ def main(argv=None):
     )
     p.add_argument(
         "--db_dir",
-        default="~/.unassigner/",
+        default=os.path.expanduser("~/.unassigner/"),
         help=(
             "Directory containing the reference database. If not provided, "
             "the default database is used."

--- a/unassigner/command.py
+++ b/unassigner/command.py
@@ -103,16 +103,16 @@ def main(argv=None):
     elif os.path.exists("unassigner_species.fasta"):
         ltp_fp = "unassigner_species.fasta"
     else:
-        if args.output_dir is None:
-            output_dir = os.path.splitext(args.query_fasta.name)[0] + "_unassigned"
-        else:
-            output_dir = args.output_dir
-
         os.makedirs(args.db_dir, exist_ok=True)
         ltp_fp = download_type_strain_data(output_dir=args.db_dir)
 
     with open(ltp_fp) as f:
         species_names = dict(parse_species_names(f))
+
+    if args.output_dir is None:
+        output_dir = os.path.splitext(args.query_fasta.name)[0] + "_unassigned"
+    else:
+        output_dir = args.output_dir
 
     writer = OutputWriter(output_dir, species_names)
 

--- a/unassigner/command.py
+++ b/unassigner/command.py
@@ -32,6 +32,13 @@ def main(argv=None):
         ),
     )
     p.add_argument(
+        "--type_strain_fasta",
+        help=(
+            "FASTA file containing sequences of type strains. If not provided, "
+            "the default database is used. Note that this WILL NOT DOWNLOAD a new db."
+        ),
+    )
+    p.add_argument(
         "--db_dir",
         default=".unassigner/",
         help=(
@@ -92,7 +99,10 @@ def main(argv=None):
 
     # Download type strain files if needed
     os.makedirs(args.db_dir, exist_ok=True)
-    metadata_fp, seqs_fp, ltp_fp = download_type_strain_data(output_dir=args.db_dir)
+    _, _, ltp_fp = download_type_strain_data(output_dir=args.db_dir)
+
+    if args.type_strain_fasta is not None:
+        ltp_fp = args.type_strain_fasta
 
     with open(ltp_fp) as f:
         species_names = dict(parse_species_names(f))

--- a/unassigner/prepare_strain_data.py
+++ b/unassigner/prepare_strain_data.py
@@ -63,7 +63,9 @@ def main(argv=None):
         action="store_true",
         help=("Remove all downloaded and processed files."),
     )
-    p.add_argument("--db-dir", help=("Filepath to download the files to."))
+    p.add_argument(
+        "--db-dir", default=".autobfx/", help=("Filepath to download the files to.")
+    )
     args = p.parse_args(argv)
 
     if args.db_dir:
@@ -94,4 +96,6 @@ def download_type_strain_data(output_dir=None, metadata_fp=None, seqs_fp=None):
         output_dir = os.getcwd()
     metadata_fp = use_or_download(metadata_fp, LTP_METADATA_URL, output_dir)
     seqs_fp = use_or_download(seqs_fp, LTP_SEQS_URL, output_dir)
-    return process_ltp_seqs(seqs_fp, output_dir)
+    ltp_fp = process_ltp_seqs(seqs_fp, output_dir)
+
+    return metadata_fp, seqs_fp, ltp_fp

--- a/unassigner/prepare_strain_data.py
+++ b/unassigner/prepare_strain_data.py
@@ -64,7 +64,9 @@ def main(argv=None):
         help=("Remove all downloaded and processed files."),
     )
     p.add_argument(
-        "--db-dir", default=".autobfx/", help=("Filepath to download the files to.")
+        "--db-dir",
+        default="~/.unassigner/",
+        help=("Filepath to download the files to."),
     )
     args = p.parse_args(argv)
 
@@ -96,6 +98,4 @@ def download_type_strain_data(output_dir=None, metadata_fp=None, seqs_fp=None):
         output_dir = os.getcwd()
     metadata_fp = use_or_download(metadata_fp, LTP_METADATA_URL, output_dir)
     seqs_fp = use_or_download(seqs_fp, LTP_SEQS_URL, output_dir)
-    ltp_fp = process_ltp_seqs(seqs_fp, output_dir)
-
-    return metadata_fp, seqs_fp, ltp_fp
+    return process_ltp_seqs(seqs_fp, output_dir)


### PR DESCRIPTION
Adds a `--db_dir` option that defaults to `.unassigner/`. Also removes the `--type_strain_fasta` option that was previously used for pointing to (but not downloading) a separate type strain LTP file. 