### PR TITLE
Add metadata JSON output with CLI arguments

### DIFF
--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -1,4 +1,5 @@
 import gzip
+import json
 import os
 import unittest
 import tempfile
@@ -37,6 +38,25 @@ class CommandTests(unittest.TestCase):
         self.assertEqual(result["region_mismatches"], 2)
         self.assertEqual(result["region_positions"], 320)
         self.assertAlmostEqual(result["probability_incompatible"], 0.003, 3)
+
+        metadata_fp = os.path.join(self.dir, "metadata.json")
+        with open(metadata_fp) as f:
+            metadata = json.load(f)
+        expected_keys = {
+            "query_fasta",
+            "output_dir",
+            "type_strain_fasta",
+            "db_dir",
+            "threshold",
+            "ref_mismatch_positions",
+            "num_cpus",
+            "soft_threshold",
+            "verbose",
+        }
+        self.assertEqual(set(metadata.keys()), expected_keys)
+        self.assertEqual(metadata["query_fasta"], self.query_fp)
+        self.assertEqual(metadata["output_dir"], self.dir)
+        self.assertEqual(metadata["type_strain_fasta"], SPECIES_FP)
 
     def test_mismatch_db(self):
         mismatch_fp = os.path.join(self.dir, "mismatch.txt.gz")

--- a/unassigner/command.py
+++ b/unassigner/command.py
@@ -1,6 +1,7 @@
 import argparse
 import datetime
 import gzip
+import json
 import logging
 import os
 import pkg_resources
@@ -115,6 +116,17 @@ def main(argv=None):
         output_dir = args.output_dir
 
     writer = OutputWriter(output_dir, species_names)
+
+    metadata = {}
+    for key, val in vars(args).items():
+        if hasattr(val, "name"):
+            metadata[key] = val.name
+        else:
+            metadata[key] = val
+    metadata["output_dir"] = output_dir
+    metadata_fp = writer.output_fp("metadata.json")
+    with open(metadata_fp, "w") as f:
+        json.dump(metadata, f)
 
     alignment_query_fp = writer.output_fp("unassigner_query.fasta")
     alignment_output_fp = writer.output_fp("unassigner_query_hits.txt")


### PR DESCRIPTION
## Summary
- write all CLI arguments to `metadata.json` in the output directory
- test that command writes metadata file with expected fields

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a256184788323b89257310886bf37